### PR TITLE
Remove Microsoft.Build.BuildEngine using which breaks build with new reference assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Diagnostics;
 using Microsoft.Build.Framework;
-using Microsoft.Build.BuildEngine;
 
 namespace Xamarin.ProjectTools
 {


### PR DESCRIPTION
The updated reference assemblies in Mono 5.0 don't depend on Microsoft.Build.Engine.dll anymore which contained the Microsoft.Build.BuildEngine namespace so this using isn't found anymore.

It was unnecessary anyway so remove it.